### PR TITLE
Add runtime API

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,6 @@
 use std::env;
+use std::fs;
+use std::path::Path;
 
 const FLAGS: &[&str] = &[
     "-I@ROOT@/lib/mswu",
@@ -31,6 +33,13 @@ const FLAGS: &[&str] = &[
     "-lwxexpat",
 ];
 
+fn save_flags(flags: &str) {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("flags.rs");
+    fs::write(&dest_path, format!("static FLAGS: &str = r\"{}\";", flags)).unwrap();
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
 fn main() {
     let pkg_path = env::var("CARGO_MANIFEST_DIR").unwrap();
     let flags = FLAGS
@@ -38,5 +47,6 @@ fn main() {
         .map(|&f| f.replace("@ROOT@", &pkg_path).replace('\n', " "))
         .collect::<Vec<_>>();
 
+    save_flags(&flags.join(" "));
     println!("cargo:cflags={}", flags.join(" "));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,14 @@
+use std::env;
 
+include!(concat!(env!("OUT_DIR"), "/flags.rs"));
+
+pub fn wx_config(args: &[&str]) -> Vec<String> {
+    let flags = FLAGS.split_whitespace().map(ToOwned::to_owned);
+    let (ldflags, cflags): (Vec<_>, Vec<_>) =
+        flags.partition(|f| f.starts_with("-l") || f.starts_with("-L"));
+    if args.contains(&"--cflags") {
+        cflags
+    } else {
+        ldflags
+    }
+}


### PR DESCRIPTION
- Add wxrust-config compatible wx_config() API.
- To be used in https://github.com/kenz-gelsoft/wxRust2/pull/166
- Moving dependency from wx-base/wx-core to other sample project requires this change.